### PR TITLE
Use profileList in JupyterHub deployment to offer several environments

### DIFF
--- a/apps/jupyterhub/values.yaml
+++ b/apps/jupyterhub/values.yaml
@@ -490,6 +490,7 @@ singleuser:
       pvcNameTemplate: claim-{username}{servername}
       volumeNameTemplate: volume-{username}{servername}
       storageAccessModes: [ReadWriteOnce]
+  # Defines the default image
   image:
     name: ghcr.io/rs-python/rs-infra-core-jupyter
     tag: "latest"
@@ -509,7 +510,14 @@ singleuser:
   cmd: null
   defaultUrl:
   extraPodConfig: {}
-  profileList: []
+  profileList:
+    - display_name: "Default (latest) environment"
+      description: "Latest RS-Python environment"
+      default: true
+    - display_name: "S3L0 dev environment"
+      description: "S3L0 RS-Python environment"
+      kubespawner_override:
+        image: ghcr.io/rs-python/rs-infra-core-jupyter:feat-rspy737-make-s3l0-processing-work
 
 # scheduling relates to the user-scheduler pods and user-placeholder pods.
 scheduling:


### PR DESCRIPTION
This allows to offer several choices before spawning the JupyterLab environment:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c8f0da74-363a-4795-98e7-b5d631e3d8e9" />
