### PR TITLE
Update to kube-scheduler 1.27.16

### DIFF
--- a/apps/jupyterhub/values.yaml
+++ b/apps/jupyterhub/values.yaml
@@ -625,7 +625,7 @@ scheduling:
       # here. We aim to stay around 1 minor version behind the latest k8s
       # version.
       #
-      tag: "v1.26.15" # ref: https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG
+      tag: "v1.27.16" # ref: https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG
       pullPolicy:
       pullSecrets: []
     nodeSelector:


### PR DESCRIPTION
The version of jupyterhub we use deploys kube-scheduler 1.26.15 with two replicas.

This version makes use of leader-elect-resource-lock=endpointsleases

So all replica create two locks named user-scheduler-lock, one of kind endpoints (legacy) and one of kind leases (new).

This causes an alert on our cluster where we search for services/endpoints without pod.

This update switches to leases only to get rid of the alert firing.

Problem, we also need to replace "endpointsleases" by "leases" in the user-scheduler config map:

https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/3.3.6/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml#L32

https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/4.0.0/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml#L20