### PR TITLE
RSPY-875: [Jupyter] Error "groups: cannot find name for group ID 1000"

### DIFF
--- a/apps/jupyterhub/values.yaml
+++ b/apps/jupyterhub/values.yaml
@@ -478,7 +478,7 @@ singleuser:
   extraContainers: []
   allowPrivilegeEscalation: false
   uid: 1001
-  fsGid: 100
+  fsGid: 1001
   serviceAccountName:
   storage:
     type: dynamic

--- a/apps/jupyterhub/values.yaml
+++ b/apps/jupyterhub/values.yaml
@@ -478,7 +478,7 @@ singleuser:
   extraContainers: []
   allowPrivilegeEscalation: false
   uid: 1001
-  fsGid: 1000
+  fsGid: 100
   serviceAccountName:
   storage:
     type: dynamic


### PR DESCRIPTION
See https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-875
Fix based on: https://github.com/jupyterhub/jupyterhub/issues/2063

Edit: corrected to value 1001 because it's the one used for the user set to replace jovyan, so the group follows the same change