### PR TITLE
Use Opentelemetry log format in L0 processor config

### DIFF
--- a/docker/eopf/resources/l0/logging_config.yaml
+++ b/docker/eopf/resources/l0/logging_config.yaml
@@ -14,7 +14,7 @@ loggers:
 
 formatters:
   console:
-    format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    format: "%(asctime)s.%(msecs)03d %(levelname)s [trace_id=%(otelTraceID)s span_id=%(otelSpanID)s resource.service.name=%(otelServiceName)s trace_sampled=%(otelTraceSampled)s] (%(name)s) %(message)s"
     datefmt: '%Y-%m-%d %H:%M:%S'
 
   file:


### PR DESCRIPTION
Use expected opentelemetry log format in L0 logging configuration. See also https://github.com/RS-PYTHON/rs-dpr-service/pull/63