### PR TITLE
RSPY-909 - Fix prefect-aws version to 0.7.4

### DIFF
--- a/docker/base/Dockerfile.jupyter
+++ b/docker/base/Dockerfile.jupyter
@@ -30,7 +30,7 @@ ENV PATH="/home/jovyan/.local/bin:${PATH}"
 ARG PYTHON_VERSION=3.13.11
 ARG DASK_TAG=2024.5.2
 ARG DASK_GATEWAY_TAG=2024.1.0
-ARG PREFECT_TAG=3.6.12
+ARG PREFECT_AWS_TAG=0.7.4
 
 USER root
 
@@ -47,7 +47,7 @@ RUN conda update -n base -c conda-forge conda && \
         dask[complete]=="${DASK_TAG}" \
         distributed=="${DASK_TAG}" \
         dask-gateway=="${DASK_GATEWAY_TAG}" \
-        prefect[aws]=="${PREFECT_TAG}" \
+        prefect[aws]=="${PREFECT_AWS_TAG}" \
         ipywidgets \
         s3fs \
         boto3 && \


### PR DESCRIPTION
Prefect-aws does not follow the same delivery cycle and version numbering than prefect.

- https://github.com/RS-PYTHON/rs-client-libraries/pull/185
- https://github.com/RS-PYTHON/rs-infra-core/pull/273
- https://github.com/RS-PYTHON/rs-workflow-env/pull/52