### PR TITLE
Update Prefect Helm chart to  2026.2.27173158

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -46,9 +46,9 @@ Below are all the FOSS (Free and open-source software) used and their respective
 
 - Prefect
   - Helm chart:
-    - Version: 2025.3.14203557
-    - Licence: [Apache License 2.0](https://github.com/PrefectHQ/prefect-helm/blob/2025.3.14203557/LICENSE)
-    - Source: <https://github.com/PrefectHQ/prefect-helm/tree/2025.3.14203557>
+    - Version: 2026.2.27173158
+    - Licence: [Apache License 2.0](https://github.com/PrefectHQ/prefect-helm/blob/2026.2.27173158/LICENSE)
+    - Source: <https://github.com/PrefectHQ/prefect-helm/tree/2026.2.27173158>
     - Copyright: Copyright The Prefect Development Team. [Authors and Contributors](https://github.com/PrefectHQ/prefect-helm/graphs/contributors)
   - Container image(s)
     - prefecthq/prefect:3.6.20-python3.13-kubernetes

--- a/apps/prefect3-server/kustomization.yaml
+++ b/apps/prefect3-server/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
 - name: prefect-server
   repo: https://prefecthq.github.io/prefect-helm
   releaseName: "{{ app_name }}"
-  version: 2025.3.14203557
+  version: 2026.2.27173158
   namespace: "{{ prefect3server.ops.namespace }}"
   valuesFile: values.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/apps/prefect3-worker-eopf/kustomization.yaml
+++ b/apps/prefect3-worker-eopf/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
 - name: prefect-worker
   repo: https://prefecthq.github.io/prefect-helm
   releaseName: "{{ app_name }}"
-  version: 2025.3.14203557
+  version: 2026.2.27173158
   namespace: "{{ prefect3worker.eopf.namespace }}"
   valuesFile: values.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/apps/prefect3-worker-general/kustomization.yaml
+++ b/apps/prefect3-worker-general/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
 - name: prefect-worker
   repo: https://prefecthq.github.io/prefect-helm
   releaseName: "{{ app_name }}"
-  version: 2025.3.14203557
+  version: 2026.2.27173158
   namespace: "{{ prefect3worker.general.namespace }}"
   valuesFile: values.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/apps/prefect3-worker-staging/kustomization.yaml
+++ b/apps/prefect3-worker-staging/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
 - name: prefect-worker
   repo: https://prefecthq.github.io/prefect-helm
   releaseName: "{{ app_name }}"
-  version: 2025.3.14203557
+  version: 2026.2.27173158
   namespace: "{{ prefect3worker.staging.namespace }}"
   valuesFile: values.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
Update to:
- https://github.com/PrefectHQ/prefect-helm/releases/tag/2026.2.27173158

To match the version of Prefect we use (3.6.20)