### PR TITLE
Revert "fix: scope prefect worker to namespace"

### DIFF
--- a/apps/prefect3-worker-eopf/values.yaml
+++ b/apps/prefect3-worker-eopf/values.yaml
@@ -290,10 +290,6 @@ worker:
       value: rs_env
       effect: NoSchedule
 
-  extraEnvVars:
-    - name: PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES
-      value: "{{ prefect3worker.eopf.namespace }}"
-
   selfHostedServerApiConfig:
     apiUrl: "http://{{ prefect3server.ops.name }}-server.{{ prefect3server.ops.namespace }}.svc.cluster.local:4200/api"
 

--- a/apps/prefect3-worker-general/values.yaml
+++ b/apps/prefect3-worker-general/values.yaml
@@ -290,10 +290,6 @@ worker:
       value: rs_env
       effect: NoSchedule
 
-  extraEnvVars:
-    - name: PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES
-      value: "{{ prefect3worker.general.namespace }}"
-
   selfHostedServerApiConfig:
     apiUrl: "http://{{ prefect3server.ops.name }}-server.{{ prefect3server.ops.namespace }}.svc.cluster.local:4200/api"
 

--- a/apps/prefect3-worker-staging/values.yaml
+++ b/apps/prefect3-worker-staging/values.yaml
@@ -290,10 +290,6 @@ worker:
       value: rs_env
       effect: NoSchedule
 
-  extraEnvVars:
-    - name: PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES
-      value: "{{ prefect3worker.staging.namespace }}"
-
   selfHostedServerApiConfig:
     apiUrl: "http://{{ prefect3server.ops.name }}-server.{{ prefect3server.ops.namespace }}.svc.cluster.local:4200/api"
 


### PR DESCRIPTION
Reverts RS-PYTHON/rs-workflow-env#73

As RS-PYTHON/rs-workflow-env#72 update to a newer version that already includes it : https://github.com/PrefectHQ/prefect-helm/blob/b6290e6e41aa8118a94e336729ad40a8c652de43/charts/prefect-worker/templates/deployment.yaml#L234

Caused duplicated env error  : https://github.com/RS-PYTHON/rs-workflow-deployment/actions/runs/23001989894/job/66788630702?pr=4