### PR TITLE
RSPY-1043 - Create a new Dask image with only CPM

### DIFF
--- a/.github/workflows/build-dask-eopf.yml
+++ b/.github/workflows/build-dask-eopf.yml
@@ -116,7 +116,7 @@ jobs:
               - docker/base/Dockerfile.dask.k8s
               - docker/base/Dockerfile.dask.local
             common:
-              - docker/eopf/build-dask-eopf.py
+              - docker/eopf/build_dask_eopf.py
               - docker/eopf/Dockerfile.dask-eopf
               - docker/eopf/Dockerfile.dask-eopf-localcluster
               - docker/eopf/resources/layer-cleanup.sh
@@ -295,7 +295,7 @@ jobs:
             options="--local"
           fi
 
-          ./docker/eopf/build-dask-eopf.py \
+          ./docker/eopf/build_dask_eopf.py \
             --gitlab_eopf_token "${{ secrets.GITLAB_EOPF_TOKEN }}" \
             --docker_tag ${{ needs.set-env.outputs.docker_tag }} \
             --labels "${{ steps.meta.outputs.labels }}" \

--- a/.github/workflows/build-dask-eopf.yml
+++ b/.github/workflows/build-dask-eopf.yml
@@ -23,7 +23,7 @@
 # - Test rs-demo with the newly built images
 #
 # On manual trigger:
-# - The user chooses which processor to build (l0, s1ard, s3olci, mockup or all) and for which target system (cluster, local, localcluster or all), and also to rebuild the base images or not
+# - The user chooses which processor to build (cpm, l0, s1ard, s3olci, mockup or all) and for which target system (cluster, local, localcluster or all), and also to rebuild the base images or not
 # - Changes are checked like in automatic mode
 # - The images built are the ones for the detected changes like in automatic mode AND the ones requested by the user
 # - rs-demo tests are run like in automatic mode
@@ -61,6 +61,7 @@ on:
         type: choice
         options:
           - all
+          - cpm
           - l0
           - s1ard
           - s3olci
@@ -97,9 +98,10 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      # Note: we tie "base" and "common" outputs to the manual trigger aswell, to trigger all the image builds anytime the workflow is triggered amnually.
+      # Note: we tie "base" and "common" outputs to the manual trigger as well, to trigger all the image builds anytime the workflow is triggered manually.
       base: ${{ steps.filter.outputs.base }}
       common: ${{ steps.filter.outputs.common }}
+      cpm: ${{ steps.filter.outputs.cpm }}
       l0: ${{ steps.filter.outputs.l0 }}
       s1ard: ${{ steps.filter.outputs.s1ard }}
       s3olci: ${{ steps.filter.outputs.s3olci }}
@@ -119,6 +121,7 @@ jobs:
               - docker/eopf/Dockerfile.dask-eopf-localcluster
               - docker/eopf/resources/layer-cleanup.sh
               - docker/eopf/resources/restore-apt.sh
+            cpm: ['docker/**/*dask-cpm.*']
             l0: ['docker/**/*dask-l0.*', 'docker/**/l0/*']
             s1ard: ['docker/**/*dask-s1ard.*']
             s3olci: ['docker/**/*dask-s3olci.*']
@@ -219,9 +222,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        proc: [l0, s1ard, s3olci]
+        proc: [cpm, l0, s1ard, s3olci]
         target: [cluster, local, localcluster] # No option = main image for cluster deployment, "local" is for local deployment and "localcluster" is for local debugging
         include:
+          - proc: cpm
+            proccondition: "${{ (needs.changes.outputs.cpm == 'true') || (needs.set-env.outputs.common_changes == 'true') || (needs.set-env.outputs.base == 'true') || ((github.event_name == 'workflow_dispatch') && ((github.event.inputs.processor == 'cpm') || (github.event.inputs.processor == 'all'))) }}"
           - proc: l0
             proccondition: "${{ (needs.changes.outputs.l0 == 'true') || (needs.set-env.outputs.common_changes == 'true') || (needs.set-env.outputs.base == 'true') || ((github.event_name == 'workflow_dispatch') && ((github.event.inputs.processor == 'l0') || (github.event.inputs.processor == 'all'))) }}"
           - proc: s1ard
@@ -234,6 +239,11 @@ jobs:
             targetcondition: "${{ (github.event_name != 'workflow_dispatch') || ( github.event.inputs.target_system == 'local') || (github.event.inputs.target_system == 'all') }}"
           - target: localcluster
             targetcondition: "${{ (github.event_name != 'workflow_dispatch') || ( github.event.inputs.target_system == 'localcluster') || (github.event.inputs.target_system == 'all') }}"
+        exclude:
+          - proc: cpm
+            target: local
+          - proc: cpm
+            target: localcluster
     steps:
 
       - name: Display build info

--- a/docker/base/build-base-images.sh
+++ b/docker/base/build-base-images.sh
@@ -35,15 +35,18 @@ CUSTOM_REQ=$(realpath "${SCRIPT_DIR}/../scripts")
 
 # We use a different python version in eopf + the dpr processors + rs-dpr-service
 PYTHON_VERSION=3.13.12
+PYTHON_VERSION_CPM=3.11.7
 PYTHON_VERSION_DPR=3.11.7
 
 # Different versions of dask and dask-gateway used (must be declared here to use update_framework_versions.sh script)
 DASK_TAG=2024.5.2
+DASK_TAG_CPM=2026.1.2
 DASK_TAG_STAGING=2026.1.2
 DASK_GATEWAY_TAG=2025.4.0
 
 # Versions used: format is [PYTHON_VERSION DASK_TAG DASK_GATEWAY_TAG]
 declare -a STAGING_VERSIONS=($PYTHON_VERSION $DASK_TAG_STAGING $DASK_GATEWAY_TAG)
+declare -a CPM_VERSIONS=($PYTHON_VERSION_CPM $DASK_TAG_CPM $DASK_GATEWAY_TAG)
 declare -a PROCESSOR_VERSIONS=($PYTHON_VERSION_DPR $DASK_TAG $DASK_GATEWAY_TAG)
 
 PREFECT_TAG=3.6.20
@@ -147,7 +150,7 @@ fi
 ########
 
 if [[ "$TARGET" == "all" || "$TARGET" == "dask" ]]; then
-    declare -a versions_list=("PROCESSOR_VERSIONS" "STAGING_VERSIONS")
+    declare -a versions_list=("PROCESSOR_VERSIONS" "CPM_VERSIONS" "STAGING_VERSIONS")
     for versions_index in "${versions_list[@]}"; do
         declare -n versions="${versions_index}"
 

--- a/docker/eopf/Dockerfile.dask-eopf
+++ b/docker/eopf/Dockerfile.dask-eopf
@@ -27,9 +27,9 @@ ARG BASE_IMAGE_TARGET=xxx
 
 # Versions used: currently all processors use Dask 2024.5.2 with Python 3.11.7, and the base images are all built with dask-gateway 2025.4.0
 # Base images for local mode also include dask-gateway-server with the same version as dask-gateway
-# ANY VERSION CHANGE MUST BE UPDATED IN THE BASE IMAGES SCRIPT GENERATOR (docker/base/build-base-images.sh) AND IN THIS FILE.
-ARG PYTHON_VERSION_DPR=3.11.7
-ARG DASK_TAG=2024.5.2
+# ANY VERSION CHANGE MUST BE UPDATED IN THE BASE IMAGES SCRIPT GENERATOR (docker/base/build-base-images.sh and docker/eopf/build_dask_eopf.py).
+ARG PYTHON_VERSION_DPR=xxx
+ARG DASK_TAG=xxx
 
 FROM ghcr.io/rs-python/dask/dask-gateway:${BASE_IMAGE_TARGET}-py${PYTHON_VERSION_DPR}-${DASK_TAG}
 

--- a/docker/eopf/Dockerfile.dask-eopf
+++ b/docker/eopf/Dockerfile.dask-eopf
@@ -16,6 +16,7 @@
 
 #
 # Target Docker image name:
+# ghcr.io/rs-python/dask/cpm
 # ghcr.io/rs-python/dask/l0
 # ghcr.io/rs-python/dask/s1ard
 # ghcr.io/rs-python/dask/s3olci

--- a/docker/eopf/build-dask-eopf.py
+++ b/docker/eopf/build-dask-eopf.py
@@ -43,7 +43,7 @@ class Image:
     k8s_name: str
 
     # Docker image name for local mode usage (registry)
-    local_name: str
+    local_name: str = ""
 
     # Name of the LocalCluster image (for debugging)
     local_cluster_name: str = ""
@@ -54,6 +54,10 @@ class Image:
 
 # All possible processor images
 all_procs = {
+    "cpm": Image(
+        k8s_name = "ghcr.io/rs-python/dask/cpm/k8s",
+        image2build = "dask-cpm",
+    ),
     "l0": Image(
         "ghcr.io/rs-python/dask/l0/k8s",
         "ghcr.io/rs-python/dask/l0/local",

--- a/docker/eopf/build_dask_eopf.py
+++ b/docker/eopf/build_dask_eopf.py
@@ -18,12 +18,12 @@
 
 import argparse
 import itertools
-import subprocess
+import subprocess  # nosec
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-# NOTE: run "./build-dask-eopf.py -h" to display help.
+# NOTE: run "./build_dask_eopf.py -h" to display help.
 
 # This script directory
 THIS_DIR = Path(__file__).parent
@@ -55,8 +55,8 @@ class Image:
 # All possible processor images
 all_procs = {
     "cpm": Image(
-        k8s_name = "ghcr.io/rs-python/dask/cpm/k8s",
-        image2build = "dask-cpm",
+        k8s_name="ghcr.io/rs-python/dask/cpm/k8s",
+        image2build="dask-cpm",
     ),
     "l0": Image(
         "ghcr.io/rs-python/dask/l0/k8s",
@@ -151,34 +151,35 @@ if not build_all:
 
 # Build all the processors, with and without local cluster
 else:
-    procs_to_build = list(itertools.product(all_procs.keys(), [False, True]))
+    procs_to_build = list(itertools.product(all_procs.keys(), [False, True]))  # type: ignore[arg-type]
 
 for proc, local_cluster in procs_to_build:
 
-    def get_dockerfile() -> Path:
+    def get_dockerfile(localcluster) -> Path:
         """Return Dockerfile to use"""
-        if local_cluster:
+        if localcluster:
             return THIS_DIR / "Dockerfile.dask-eopf-localcluster"
         # default
         return THIS_DIR / "Dockerfile.dask-eopf"
 
-    def run_command(command: list[str]):
+    def run_command(cmd: list[str]):
         """Run command line"""
         print(f"""
 #########
 # BUILD #
 #########
 
-{' '.join(command)}
+{' '.join(cmd)}
 """)
 
-        if code := subprocess.run(
-            command,
+        if code := subprocess.run(  # nosec
+            cmd,
+            check=False,
             env={"GITLAB_EOPF_TOKEN": args.gitlab_eopf_token},
         ).returncode:
             joined = "' '"
             raise RuntimeError(
-                f"Error running command:\n'{joined.join(command)}'\nReturn code: {code}",
+                f"Error running command:\n'{joined.join(cmd)}'\nReturn code: {code}",
             )
 
     # Docker image information
@@ -198,9 +199,9 @@ for proc, local_cluster in procs_to_build:
         "--build-arg",
         f"IMAGE2BUILD={image.image2build}",
         "--secret",
-        f"id=GITLAB_EOPF_TOKEN",
+        "id=GITLAB_EOPF_TOKEN",
         "-f",
-        str(get_dockerfile()),
+        str(get_dockerfile(local_cluster)),
         "-t",
         f"{registry}:{args.docker_tag}",
         "--progress=plain",

--- a/docker/eopf/build_dask_eopf.py
+++ b/docker/eopf/build_dask_eopf.py
@@ -214,6 +214,11 @@ for proc, local_cluster in procs_to_build:
     if not local_cluster:
         command += ["--build-arg", f"BASE_IMAGE_TARGET={registry.rsplit('/', 1)[1]}"]
 
+    if proc == 'cpm':
+        command += ["--build-arg", "PYTHON_VERSION_DPR=3.11.7", "--build-arg", "DASK_TAG=2026.1.2"]
+    else:
+        command += ["--build-arg", "PYTHON_VERSION_DPR=3.11.7", "--build-arg", "DASK_TAG=2024.5.2"]
+
     # Build image
     run_command(command + labels)
 

--- a/docker/eopf/resources/requirements-dask-cpm.txt
+++ b/docker/eopf/resources/requirements-dask-cpm.txt
@@ -1,0 +1,16 @@
+# Copyright 2023-2026 Airbus, CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--extra-index-url https://__token__:${GITLAB_EOPF_TOKEN}@gitlab.eopf.copernicus.eu/api/v4/projects/14/packages/pypi/simple # eopf cpm
+eopf>=2.8.0,<3

--- a/docker/jupyter/resources/00-read-env.py
+++ b/docker/jupyter/resources/00-read-env.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#Script to automatically import environment variables from $HOME/.env file
-import os
-from dotenv import load_dotenv
-from pathlib import Path
+# pylint: disable=invalid-name
+""" Script to automatically import environment variables from $HOME/.env file """
 
-env_path = Path(os.getenv("HOME")) / '.env'
+from pathlib import Path
+from dotenv import load_dotenv
+
+env_path = Path.home() / '.env'
 
 load_dotenv(dotenv_path=env_path)

--- a/docker/jupyter/resources/jupyter_server_config.py
+++ b/docker/jupyter/resources/jupyter_server_config.py
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import stat
-import subprocess
-from pathlib import Path
 
-from jupyter_core.paths import jupyter_data_dir
+"""Jupyter config file: https://jupyter-server.readthedocs.io/en/latest/users/configuration.html"""
 
-c.ContentsManager.allow_hidden = True
+c.ContentsManager.allow_hidden = True  # type: ignore[name-defined] # pylint: disable=undefined-variable # noqa: F821


### PR DESCRIPTION
New Dask image to run latest version of cpm for SAFE to ZARR product conversion:

```python
def init_dask_cluster_cpm(
    *args,
    image=("ghcr.io/rs-python/dask/cpm/k8s:latest"),
    cluster_label="dask-cpm",
    **kwargs,
):
    return init_dask_cluster_eopf(
        *args,
        local_mode_address=None,
        local_mode_address_public=None,
        image=image,
        cluster_label=cluster_label,
        **kwargs,
    )

```

Pull requests:
- https://github.com/RS-PYTHON/rs-workflow-env/pull/84
- https://github.com/RS-PYTHON/rs-demo/pull/300