### PR TITLE
RSPY-1025 - Use main branch of S1-ARD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints

--- a/docker/eopf/Dockerfile.dask-eopf
+++ b/docker/eopf/Dockerfile.dask-eopf
@@ -59,19 +59,19 @@ ADD ./resources/requirements-*.txt /opt
 # GITLAB_EOPF_TOKEN=$(cat /run/secrets/GITLAB_EOPF_TOKEN) pip install ...
 RUN --mount=type=secret,id=GITLAB_EOPF_TOKEN,env=GITLAB_EOPF_TOKEN \
     git config --global url."https://__token__:${GITLAB_EOPF_TOKEN}@gitlab.eopf.copernicus.eu/".insteadOf "https://gitlab.eopf.copernicus.eu/" && \
-    pip install -U pip && \
-    pip install -U -r /opt/requirements-${IMAGE2BUILD}.txt && \
+    pip install --only-binary=:all: -U pip && \
+    pip install --prefer-binary -U -r /opt/requirements-${IMAGE2BUILD}.txt && \
     layer-cleanup.sh && \
     rm -rf /opt/requirements-*.txt
 
 # Install complete dask subsets
-RUN pip install dask[complete] && layer-cleanup.sh
+RUN pip install --only-binary=:all: dask[complete] && layer-cleanup.sh
 
 # Other installations
 RUN restore-apt.sh && apt update && apt install -y graphviz proj-bin proj-data python3-pydot && layer-cleanup.sh
 
 # Install and auto configure opentelemetry
-RUN pip install opentelemetry-distro opentelemetry-exporter-otlp "opentelemetry-instrumentation-eopf>=0.2.5" && \
+RUN pip install --only-binary=:all: opentelemetry-distro opentelemetry-exporter-otlp "opentelemetry-instrumentation-eopf>=0.2.5" && \
     opentelemetry-bootstrap -a install && \
     layer-cleanup.sh
 

--- a/docker/eopf/Dockerfile.dask-eopf
+++ b/docker/eopf/Dockerfile.dask-eopf
@@ -68,7 +68,7 @@ RUN --mount=type=secret,id=GITLAB_EOPF_TOKEN,env=GITLAB_EOPF_TOKEN \
 RUN pip install dask[complete] && layer-cleanup.sh
 
 # Other installations
-RUN restore-apt.sh && apt update && apt install -y python3-pydot graphviz && layer-cleanup.sh
+RUN restore-apt.sh && apt update && apt install -y graphviz proj-bin proj-data python3-pydot && layer-cleanup.sh
 
 # Install and auto configure opentelemetry
 RUN pip install opentelemetry-distro opentelemetry-exporter-otlp "opentelemetry-instrumentation-eopf>=0.2.5" && \

--- a/docker/eopf/Dockerfile.dask-eopf
+++ b/docker/eopf/Dockerfile.dask-eopf
@@ -49,7 +49,7 @@ RUN chmod 755 /usr/local/bin/layer-cleanup.sh /usr/local/bin/restore-apt.sh
 # System installations
 RUN \
     restore-apt.sh && apt update && \
-    apt install -y git && \
+    apt install -y git curl && \
     layer-cleanup.sh
 
 # Install processor and eopf
@@ -89,7 +89,7 @@ RUN \
     rm -rf /opt/resources
 
 # Clean everything
-RUN apt autoremove -y git && layer-cleanup.sh
+RUN apt autoremove -y git curl && layer-cleanup.sh
 
 # Remove custom scripts
 RUN rm -f /usr/local/bin/layer-cleanup.sh /usr/local/bin/restore-apt.sh

--- a/docker/eopf/Dockerfile.dask-eopf-localcluster
+++ b/docker/eopf/Dockerfile.dask-eopf-localcluster
@@ -40,7 +40,7 @@ RUN chmod 755 /usr/local/bin/layer-cleanup.sh /usr/local/bin/restore-apt.sh
 # System installations
 RUN \
     restore-apt.sh && apt update && \
-    apt install -y git && \
+    apt install -y git curl && \
     layer-cleanup.sh
 
 # Install processor and eopf
@@ -88,7 +88,7 @@ RUN \
     rm -rf /opt/resources
 
 # Clean everything
-RUN apt autoremove -y git && layer-cleanup.sh
+RUN apt autoremove -y git curl && layer-cleanup.sh
 
 # Remove custom scripts
 RUN rm -f /usr/local/bin/layer-cleanup.sh /usr/local/bin/restore-apt.sh

--- a/docker/eopf/Dockerfile.dask-eopf-localcluster
+++ b/docker/eopf/Dockerfile.dask-eopf-localcluster
@@ -50,13 +50,13 @@ ADD ./resources/requirements-*.txt /opt
 # GITLAB_EOPF_TOKEN=$(cat /run/secrets/GITLAB_EOPF_TOKEN) pip install ...
 RUN --mount=type=secret,id=GITLAB_EOPF_TOKEN,env=GITLAB_EOPF_TOKEN \
     git config --global url."https://__token__:${GITLAB_EOPF_TOKEN}@gitlab.eopf.copernicus.eu/".insteadOf "https://gitlab.eopf.copernicus.eu/" && \
-    pip install -U pip && \
-    pip install -U -r /opt/requirements-${IMAGE2BUILD}.txt && \
+    pip install --only-binary=:all: -U pip && \
+    pip install --prefer-binary -U -r /opt/requirements-${IMAGE2BUILD}.txt && \
     layer-cleanup.sh && \
     rm -rf /opt/requirements-*.txt
 
 # Install complete dask subsets
-RUN pip install dask[complete] && layer-cleanup.sh
+RUN pip install --only-binary=:all: dask[complete] && layer-cleanup.sh
 
 # Other installations
 RUN \
@@ -64,13 +64,13 @@ RUN \
     apt update && \
     apt install -y \
         python3-pydot graphviz && \
-    pip install \
+    pip install --only-binary=:all: \
         bokeh">=3.1.0" \
         jupyter-server-proxy && \
     layer-cleanup.sh
 
 # Install and auto configure opentelemetry
-RUN pip install opentelemetry-distro opentelemetry-exporter-otlp "opentelemetry-instrumentation-eopf>=0.2.5" && \
+RUN pip install --only-binary=:all: opentelemetry-distro opentelemetry-exporter-otlp "opentelemetry-instrumentation-eopf>=0.2.5" && \
     opentelemetry-bootstrap -a install && \
     layer-cleanup.sh
 

--- a/docker/eopf/resources/post-install-dask-s1ard.sh
+++ b/docker/eopf/resources/post-install-dask-s1ard.sh
@@ -22,5 +22,5 @@ PROJ_LOCAL_DIR="/usr/local/lib/python3.13/site-packages/pyproj/proj_dir/share/pr
 # Download the required grid files
 # shellcheck disable=SC2043
 for grid_filename in us_nga_egm08_25.tif ; do
-  curl -fLs "${PROJ_CDN_URL}/${grid_filename}" -o "${PROJ_LOCAL_DIR}/${grid_filename}"
+  curl -fLs --proto '=https' --proto-redir '=https' "${PROJ_CDN_URL}/${grid_filename}" -o "${PROJ_LOCAL_DIR}/${grid_filename}"
 done

--- a/docker/eopf/resources/post-install-dask-s1ard.sh
+++ b/docker/eopf/resources/post-install-dask-s1ard.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2023-2026 Airbus, CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+set -x
+
+PROJ_CDN_URL="https://cdn.proj.org"
+PROJ_LOCAL_DIR="/usr/local/lib/python3.13/site-packages/pyproj/proj_dir/share/proj"
+
+# Download the required grid files
+# shellcheck disable=SC2043
+for grid_filename in us_nga_egm08_25.tif ; do
+  curl -fLs "${PROJ_CDN_URL}/${grid_filename}" -o "${PROJ_LOCAL_DIR}/${grid_filename}"
+done

--- a/docker/eopf/resources/requirements-dask-s1ard.txt
+++ b/docker/eopf/resources/requirements-dask-s1ard.txt
@@ -21,8 +21,8 @@
 --extra-index-url https://__token__:${GITLAB_EOPF_TOKEN}@gitlab.eopf.copernicus.eu/api/v4/projects/201/packages/pypi/simple # s1-ard
 
 # Install s1 ard.
-#git+https://__token__:${GITLAB_EOPF_TOKEN}@gitlab.eopf.copernicus.eu/S1/s1-ard@1.2.0rc1
-s1-ard==1.2.0rc1
+git+https://__token__:${GITLAB_EOPF_TOKEN}@gitlab.eopf.copernicus.eu/S1/s1-ard@main
+#s1-ard==1.2.0rc1
 
 # other python dependencies
 #graphviz


### PR DESCRIPTION
- Use main branch of [S1-ARD](https://gitlab.eopf.copernicus.eu/S1/s1-ard) processor to get latest fixes
- Include [proj-data](https://github.com/OSGeo/PROJ-data) Ubuntu package in all processor images
- Download `us_nga_egm08_25.tif` grid from [PROJ CDN](https://cdn.proj.org/) in S1-ARD image, required for the DEM step