### PR TITLE
RSPY-1025 - Update S1ARD and staging to Dask 2026.3.0

### DIFF
--- a/docker/base/Dockerfile.jupyter
+++ b/docker/base/Dockerfile.jupyter
@@ -15,7 +15,7 @@
 
 #
 # Target Docker image names:
-# ghcr.io/rs-python/quay.io/jupyter/base-notebook:hub-xxx
+# ghcr.io/rs-python/quay.io/jupyter/base-notebook:hub-xxx-pyzzz-vn
 #
 
 # shellcheck disable=SC2102,SC1091

--- a/docker/base/build-base-images.sh
+++ b/docker/base/build-base-images.sh
@@ -140,7 +140,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "dask" ]]; then
     # After conversion to json, its content should be something like:
     # {"deps": [
     # {"python_version": "3.11.7", "dask_version": "2024.5.2"},
-    # {"python_version": "3.13.12", "dask_version": "2026.1.2"},
+    # {"python_version": "3.13.12", "dask_version": "2026.3.0"},
     # ...
     deps_file="${CUSTOM_REQ}/dask-cluster-versions.yml"
 

--- a/docker/base/build-base-images.sh
+++ b/docker/base/build-base-images.sh
@@ -17,7 +17,7 @@
 # Build the base Docker images that are used in the cluster and in the ci/cd.
 # Target Docker image names:
 # ghcr.io/rs-python/python:xxx-slim-bookworm
-# ghcr.io/rs-python/quay.io/jupyter/base-notebook:hub-xxx
+# ghcr.io/rs-python/quay.io/jupyter/base-notebook:hub-xxx-pyzzz-vn
 # ghcr.io/rs-python/dask/dask-gateway:xxx-pyzzz-yyy
 # ghcr.io/rs-python/prefecthq/prefect:xxx-pyzzz
 # ghcr.io/rs-python/prefecthq/prefect:xxx-pyzzz-k8s
@@ -111,7 +111,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "jupyter" ]]; then
 
     jupyter_dockerfile="Dockerfile.jupyter"
     jupyter_base="quay.io/jupyter/base-notebook:hub-${JUPYTER_HUB_VERSION}"
-    jupyter_suffix="-py${PYTHON_VERSION}"
+    jupyter_suffix="-py${PYTHON_VERSION}-v1"
 
     # Add our hosting github organization to the docker image
     jupyter_target="ghcr.io/rs-python/${jupyter_base}${jupyter_suffix}"

--- a/docker/eopf/build_dask_eopf.py
+++ b/docker/eopf/build_dask_eopf.py
@@ -73,7 +73,7 @@ all_procs = {
     # WARNING: Up to first official relase, release-candidate revision is hard-coded in requirements-dask-cpm3.txt
     "cpm3": Image(
         python_version="3.13.12",
-        dask_version="2026.1.2",
+        dask_version="2026.3.0",
         k8s_name="ghcr.io/rs-python/dask/cpm3/k8s",
         local_name="ghcr.io/rs-python/dask/cpm3/local",
         local_cluster_name="ghcr.io/rs-python/dask/cpm3/localcluster",
@@ -89,7 +89,7 @@ all_procs = {
     ),
     "s1ard": Image(
         python_version="3.13.12",
-        dask_version="2026.1.2",
+        dask_version="2026.3.0",
         k8s_name="ghcr.io/rs-python/dask/s1ard/k8s",
         local_name="ghcr.io/rs-python/dask/s1ard/local",
         local_cluster_name="ghcr.io/rs-python/dask/s1ard/localcluster",

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -20,7 +20,7 @@
 ARG PYTHON_VERSION=3.13.12
 ARG JUPYTER_HUB_VERSION=5.4.3
 
-FROM ghcr.io/rs-python/quay.io/jupyter/base-notebook:hub-${JUPYTER_HUB_VERSION}-py${PYTHON_VERSION}
+FROM ghcr.io/rs-python/quay.io/jupyter/base-notebook:hub-${JUPYTER_HUB_VERSION}-py${PYTHON_VERSION}-v1
 
 ARG PYTHON_VERSION=3.13.12
 ARG DASK_TAG=2024.5.2

--- a/docker/scripts/create-jupyter-kernels.sh
+++ b/docker/scripts/create-jupyter-kernels.sh
@@ -29,7 +29,7 @@ fi
 # After conversion to json, its content should be something like:
 # {"deps": [
 # {"python_version": "3.11.7", "dask_version": "2024.5.2"},
-# {"python_version": "3.13.12", "dask_version": "2026.1.2"},
+# {"python_version": "3.13.12", "dask_version": "2026.3.0"},
 # ...
 echo "Read: '$deps_file'"
 cat "$deps_file"

--- a/docker/scripts/dask-cluster-versions.yml
+++ b/docker/scripts/dask-cluster-versions.yml
@@ -24,4 +24,4 @@ deps:
     dask_version: "2026.1.2"
 
   - python_version: "3.13.12"
-    dask_version: "2026.1.2"
+    dask_version: "2026.3.0"

--- a/docs/dask_images.md
+++ b/docs/dask_images.md
@@ -72,10 +72,10 @@ Each base image contains a Jupyter environment with the libraries "dask", "distr
 
 Currently, here are the four variants of Dask base images created and their usage. The tag follows the naming convention `<TARGET SYSTEM>-py<PYTHON VERSION>-<DASK VERSION>`.
 
-- `ghcr.io/rs-python/dask/dask-gateway:k8s-py3.13.12-2026.1.2`: for staging on cluster mode. The staging runs with Python 3.13.12 and usually the latest version of Dask as it has a direct dependency to it that can be updated regularly.
-- `ghcr.io/rs-python/dask/dask-gateway:k8s-py3.11.7-2024.5.2`: for processors on cluster mode. The processors are currently in Python 3.11.7 and their dependency to Dask is more complicated to update as it is linked to a third-party dependency, so it uses an older version.
-- `ghcr.io/rs-python/dask/dask-gateway:local-py3.13.12-2026.1.2`: for staging on local mode.
-- `ghcr.io/rs-python/dask/dask-gateway:local-py3.11.7-2024.5.2`: for processors on local mode.
+- `ghcr.io/rs-python/dask/dask-gateway:k8s-py3.13.12-2026.3.0`: for staging and S1 ARD on cluster mode. The staging runs with Python 3.13.12 and usually the latest version of Dask as it has a direct dependency to it that can be updated regularly.
+- `ghcr.io/rs-python/dask/dask-gateway:k8s-py3.11.7-2024.5.2`: for L0 processors on cluster mode. The L0 processors are currently in Python 3.11.7 and their dependency to Dask is more complicated to update as it is linked to a third-party dependency, so it uses an older version.
+- `ghcr.io/rs-python/dask/dask-gateway:local-py3.13.12-2026.3.0`: for staging and S1 ARD processor on local mode.
+- `ghcr.io/rs-python/dask/dask-gateway:local-py3.11.7-2024.5.2`: for L0 processors on local mode.
 
 ## Processor images
 


### PR DESCRIPTION
Update to Dask 2026.3.0 for latest version of S1-ARD processor.

Pull requests:
- https://github.com/RS-PYTHON/rs-dpr-service/pull/134
- https://github.com/RS-PYTHON/rs-workflow-env/pull/123
- https://github.com/RS-PYTHON/rs-server/pull/1918
- https://github.com/RS-PYTHON/rs-demo/pull/335
- https://github.com/RS-PYTHON/rs-server-deployment/pull/79
- https://github.com/RS-PYTHON/rs-client-libraries/pull/346