### PR TITLE
RSPY-1109 - Use correct rs-demo branch with cache bust

### DIFF
--- a/.github/workflows/build-dask-eopf.yml
+++ b/.github/workflows/build-dask-eopf.yml
@@ -107,7 +107,7 @@ jobs:
       s3olci: ${{ steps.filter.outputs.s3olci }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/build-jupyter.yml
+++ b/.github/workflows/build-jupyter.yml
@@ -72,7 +72,7 @@ jobs:
       base: ${{ steps.filter.outputs.base }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -205,6 +205,19 @@ jobs:
           repository: RS-PYTHON/rs-client-libraries
           run-id: ${{ steps.rs-client-run-id.outputs.run-id }}
 
+      - name: Resolve rs-demo branch
+        id: rs-demo-branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT_BRANCH: ${{ needs.set-env.outputs.branch_name }}
+        run: |
+          if gh api "repos/${{ github.repository_owner }}/rs-demo/branches/${CURRENT_BRANCH}" --silent 2>/dev/null; then
+            echo "branch=${CURRENT_BRANCH}" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=develop" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
       - id: publish-docker
         uses: RS-PYTHON/actions/.github/actions/publish-docker@develop
         with:
@@ -212,6 +225,9 @@ jobs:
           build_context_path: ./docker/jupyter
           image_suffix: -jupyter
           image_tags: ${{ needs.set-env.outputs.docker_tags }}
+          build_args: |
+            CACHEBUST=${{ github.run_id }}
+            RS_DEMO_BRANCH=${{ steps.rs-demo-branch.outputs.branch }}
           dockerhub_username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -102,10 +102,6 @@ RUN curl -L -o /tmp/firefox.tar.xz "https://download.mozilla.org/?product=firefo
     ln -s /opt/firefox/firefox /usr/bin/firefox && \
     rm /tmp/firefox.tar.xz
 
-# Clone rs-demo repository
-RUN cd /opt && \
-    git clone https://github.com/RS-PYTHON/rs-demo.git
-
 COPY --chown=rspy:rspy ./resources/00-read-env.py /tmp/00-read-env.py
 COPY --chown=rspy:rspy ./resources/jupyter_server_config.py /tmp/jupyter_server_config.py
 
@@ -114,6 +110,13 @@ RUN chmod 755 /usr/local/bin/start-notebook.sh
 
 # Remove custom scripts
 RUN rm -f /usr/local/bin/layer-cleanup.sh /usr/local/bin/restore-apt.sh
+
+# Clone rs-demo repository
+# CACHEBUST invalidates the cache so git clone always fetches the latest commits
+ARG CACHEBUST
+ARG RS_DEMO_BRANCH=develop
+RUN cd /opt && \
+    git clone --single-branch --branch "${RS_DEMO_BRANCH}" https://github.com/RS-PYTHON/rs-demo.git
 
 ENTRYPOINT ["start-notebook.sh"]
 


### PR DESCRIPTION
Make sure that building the Jupyter docker image uses the latest version of the rs-demo notebooks from the expected branch