### PR TITLE
RSPY-1109 - Include Prefect in Jupyter kernels

### DIFF
--- a/docker/scripts/create-jupyter-kernels.sh
+++ b/docker/scripts/create-jupyter-kernels.sh
@@ -60,6 +60,7 @@ for dep in $deps; do
         ipykernel \
         "dask[complete]==${dask_version}" \
         dask-gateway=="${DASK_GATEWAY_TAG}" \
+        prefect=="${PREFECT_TAG}" \
         ipywidgets
 
     # Install the Jupyter kernel


### PR DESCRIPTION
To resolve this error when running `init_dask_cluster_s3olci.ipynb` from jupyterhub:

```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
File [~/notebooks/resources/dask_clusters/cluster_config/load_prefect_variable.py:62](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/notebooks/resources/dask_clusters/cluster_config/load_prefect_variable.py#line=61), in load_prefect_values_from_variable()
     61 try:
---> 62     from prefect.variables import Variable
     63 except ImportError as exc:

File [~/.local/lib/python3.11/site-packages/prefect/variables.py:3](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/.local/lib/python3.11/site-packages/prefect/variables.py#line=2)
      1 from typing import Any, Callable, Optional
----> 3 from pydantic import BaseModel, Field
      5 from prefect._internal.compatibility.async_dispatch import async_dispatch

ModuleNotFoundError: No module named 'pydantic'

The above exception was the direct cause of the following exception:

RuntimeError                              Traceback (most recent call last)
Cell In[3], line 4
      1 # Init cluster from this venv kernel
      2 from resources.dask_clusters.dask_utils import *
      3 from resources.dask_clusters.dask_venv import *
----> 4 from resources.dask_clusters.cluster_config import * # see cluster_config.__init__
      5 
      6 gateway, cluster, client = init_dask_cluster_s3olci_venv(
      7     scale=scale,

File [~/notebooks/resources/dask_clusters/cluster_config/__init__.py:17](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/notebooks/resources/dask_clusters/cluster_config/__init__.py#line=16)
      1 # Copyright 2023-2026 Airbus, CS Group
      2 #
      3 # Licensed under the Apache License, Version 2.0 (the "License");
   (...)     12 # See the License for the specific language governing permissions and
     13 # limitations under the License.
     15 """KubeClusterConfig, see: https://github.com/RS-PYTHON/rs-infra-core/blob/develop/docs/how-to/Dask-gateway.md"""
---> 17 from .dpr_container_config import *
     18 from .dpr_olci_worker_pod_config import *
     19 from .dpr_scheduler_pod_config import *

File [~/notebooks/resources/dask_clusters/cluster_config/dpr_container_config.py:28](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/notebooks/resources/dask_clusters/cluster_config/dpr_container_config.py#line=27)
     23     shared_disk_mounts = extract_shared_disk_mounts(prefect_values)
     25     return {"volumeMounts": shared_disk_mounts}
---> 28 dpr_container_config = resolve_dpr_container_config()
     29 print(f"[dpr_container_config] Resolved configuration: {dpr_container_config}")

File [~/notebooks/resources/dask_clusters/cluster_config/dpr_container_config.py:22](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/notebooks/resources/dask_clusters/cluster_config/dpr_container_config.py#line=21), in resolve_dpr_container_config()
     20 def resolve_dpr_container_config() -> dict:
     21     """Return the DPR container config with shared-disk mounts from Prefect."""
---> 22     prefect_values = get_prefect_values_sync()
     23     shared_disk_mounts = extract_shared_disk_mounts(prefect_values)
     25     return {"volumeMounts": shared_disk_mounts}

File [~/notebooks/resources/dask_clusters/cluster_config/load_prefect_variable.py:100](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/notebooks/resources/dask_clusters/cluster_config/load_prefect_variable.py#line=99), in get_prefect_values_sync()
     96 except RuntimeError:
     97     # If the environment variable is not set, try to load from Prefect variable service
     98     pass
--> 100 return load_prefect_values_from_variable()

File [~/notebooks/resources/dask_clusters/cluster_config/load_prefect_variable.py:64](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/notebooks/resources/dask_clusters/cluster_config/load_prefect_variable.py#line=63), in load_prefect_values_from_variable()
     62     from prefect.variables import Variable
     63 except ImportError as exc:
---> 64     raise RuntimeError(
     65         "Prefect is required to resolve DPR container config values",
     66     ) from exc
     68 try:
     69     result = Variable.get(PREFECT_VAR_NAME)

RuntimeError: Prefect is required to resolve DPR container config values
```