### PR TITLE
RSPY-1109 - Include python_socks in Jupyter kernels (required by prefect)

### DIFF
--- a/docker/scripts/create-jupyter-kernels.sh
+++ b/docker/scripts/create-jupyter-kernels.sh
@@ -61,6 +61,7 @@ for dep in $deps; do
         "dask[complete]==${dask_version}" \
         dask-gateway=="${DASK_GATEWAY_TAG}" \
         prefect=="${PREFECT_TAG}" \
+        python-socks \
         ipywidgets
 
     # Install the Jupyter kernel


### PR DESCRIPTION
To avoid this new error:
```

---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
File [~/notebooks/resources/dask_clusters/cluster_config/load_prefect_variable.py:69](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/notebooks/resources/dask_clusters/cluster_config/load_prefect_variable.py#line=68), in load_prefect_values_from_variable()
     68 try:
---> 69     result = Variable.get(PREFECT_VAR_NAME)
     70 except Exception as exc:

File [~/.local/lib/python3.11/site-packages/prefect/_internal/compatibility/async_dispatch.py:91](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/.local/lib/python3.11/site-packages/prefect/_internal/compatibility/async_dispatch.py#line=90), in async_dispatch.<locals>.decorator.<locals>.wrapper(*args, **kwargs)
     89 _sync = kwargs.pop("_sync", None)
     90 should_run_sync = (
---> 91     bool(_sync) if _sync is not None else not is_in_async_context()
     92 )
     93 fn = sync_fn if should_run_sync else async_impl

File [~/.local/lib/python3.11/site-packages/prefect/_internal/compatibility/async_dispatch.py:26](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/.local/lib/python3.11/site-packages/prefect/_internal/compatibility/async_dispatch.py#line=25), in is_in_async_context()
     18 """
     19 Returns True if called from within an async context.
     20 
   (...)     24     - a task or flow that is async
     25 """
---> 26 from prefect.context import get_run_context
     27 from prefect.exceptions import MissingContextError

File [~/.local/lib/python3.11/site-packages/prefect/context.py:26](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/.local/lib/python3.11/site-packages/prefect/context.py#line=25)
     25 from prefect.client.schemas import FlowRun, TaskRun
---> 26 from prefect.events.worker import EventsWorker
     27 from prefect.exceptions import MissingContextError

File [~/.local/lib/python3.11/site-packages/prefect/events/__init__.py:45](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/.local/lib/python3.11/site-packages/prefect/events/__init__.py#line=44)
     25 from .actions import (
     26     ActionTypes,
     27     Action,
   (...)     43     DeclareIncident,
     44 )
---> 45 from .clients import get_events_client, get_events_subscriber
     46 from .utilities import emit_event

File [~/.local/lib/python3.11/site-packages/prefect/events/clients.py:28](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/.local/lib/python3.11/site-packages/prefect/events/clients.py#line=27)
     27 from prometheus_client import Counter
---> 28 from python_socks.async_.asyncio import Proxy
     29 from typing_extensions import Self

ModuleNotFoundError: No module named 'python_socks'

The above exception was the direct cause of the following exception:

RuntimeError                              Traceback (most recent call last)
Cell In[3], line 4
      1 # Init cluster from this venv kernel
      2 from resources.dask_clusters.dask_utils import *
      3 from resources.dask_clusters.dask_venv import *
----> 4 from resources.dask_clusters.cluster_config import * # see cluster_config.__init__
      5 
      6 gateway, cluster, client = init_dask_cluster_s3olci_venv(
      7     scale=scale,

File [~/notebooks/resources/dask_clusters/cluster_config/__init__.py:17](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/notebooks/resources/dask_clusters/cluster_config/__init__.py#line=16)
      1 # Copyright 2023-2026 Airbus, CS Group
      2 #
      3 # Licensed under the Apache License, Version 2.0 (the "License");
   (...)     12 # See the License for the specific language governing permissions and
     13 # limitations under the License.
     15 """KubeClusterConfig, see: https://github.com/RS-PYTHON/rs-infra-core/blob/develop/docs/how-to/Dask-gateway.md"""
---> 17 from .dpr_container_config import *
     18 from .dpr_olci_worker_pod_config import *
     19 from .dpr_scheduler_pod_config import *

File [~/notebooks/resources/dask_clusters/cluster_config/dpr_container_config.py:28](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/notebooks/resources/dask_clusters/cluster_config/dpr_container_config.py#line=27)
     23     shared_disk_mounts = extract_shared_disk_mounts(prefect_values)
     25     return {"volumeMounts": shared_disk_mounts}
---> 28 dpr_container_config = resolve_dpr_container_config()
     29 print(f"[dpr_container_config] Resolved configuration: {dpr_container_config}")

File [~/notebooks/resources/dask_clusters/cluster_config/dpr_container_config.py:22](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/notebooks/resources/dask_clusters/cluster_config/dpr_container_config.py#line=21), in resolve_dpr_container_config()
     20 def resolve_dpr_container_config() -> dict:
     21     """Return the DPR container config with shared-disk mounts from Prefect."""
---> 22     prefect_values = get_prefect_values_sync()
     23     shared_disk_mounts = extract_shared_disk_mounts(prefect_values)
     25     return {"volumeMounts": shared_disk_mounts}

File [~/notebooks/resources/dask_clusters/cluster_config/load_prefect_variable.py:100](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/notebooks/resources/dask_clusters/cluster_config/load_prefect_variable.py#line=99), in get_prefect_values_sync()
     96 except RuntimeError:
     97     # If the environment variable is not set, try to load from Prefect variable service
     98     pass
--> 100 return load_prefect_values_from_variable()

File [~/notebooks/resources/dask_clusters/cluster_config/load_prefect_variable.py:71](https://processing.ops.rs-python.eu/jupyter/user/vprivat/lab/tree/notebooks/init-dask-clusters/notebooks/resources/dask_clusters/cluster_config/load_prefect_variable.py#line=70), in load_prefect_values_from_variable()
     69     result = Variable.get(PREFECT_VAR_NAME)
     70 except Exception as exc:
---> 71     raise RuntimeError(
     72         f"Unable to load Prefect variable {PREFECT_VAR_NAME!r} and no environment payload was available",
     73     ) from exc
     75 if inspect.isawaitable(result):
     76     try:

RuntimeError: Unable to load Prefect variable 'processing-storage-configuration' and no environment payload was available
```