### PR TITLE
RSPY-1131: Error building Dask base image py3.13.12-2026.3.0

### DIFF
--- a/docker/base/Dockerfile.python
+++ b/docker/base/Dockerfile.python
@@ -30,9 +30,11 @@ RUN chmod 755 /usr/local/bin/layer-cleanup.sh
 RUN \
     apt update && \
     apt upgrade -y && \
-    pip install -U pip && \
+    pip install -U pip==26.1.2 && \
     layer-cleanup.sh && \
     rm -f /usr/local/bin/layer-cleanup.sh
+# NOTE: pip version forced to 26.1.2 because of a bug using pip 26.2, see https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-1131
+# Please remove hardcoded version when a fixed version of pip is available
 
 # Set labels based on the Open Containers Initiative (OCI):
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

--- a/docker/base/Dockerfile.python
+++ b/docker/base/Dockerfile.python
@@ -33,7 +33,7 @@ RUN \
     pip install -U pip==26.1.2 && \
     layer-cleanup.sh && \
     rm -f /usr/local/bin/layer-cleanup.sh
-# NOTE: pip version forced to 26.1.2 because of a bug using pip 26.2, see https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-1131
+# NOTE: pip version forced to 26.1.2 because of a bug using pip 26.2, see https://github.com/jazzband/pip-tools/issues/2436
 # Please remove hardcoded version when a fixed version of pip is available
 
 # Set labels based on the Open Containers Initiative (OCI):


### PR DESCRIPTION
See: https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-1131

Fixed version of pip to 26.1.2 because the bug happens only with pip 26.2.
This fix will have to be removed once a fixed version of pip will be released.