### PR TITLE
Skip .pyc generation to shrink the Jupyter kernels layer

### DIFF
--- a/docker/scripts/create-jupyter-kernels.sh
+++ b/docker/scripts/create-jupyter-kernels.sh
@@ -55,9 +55,11 @@ for dep in $deps; do
     conda init bash zsh && source ~/.zshrc # note: sourcing ~/.bashrc doesn't work because we're in non-interactive mode
     conda activate "$dep_name"
 
-    # Install dependencies
+    # Install dependencies.
+    # --no-compile skips generating .pyc bytecode caches: it's regenerated lazily on first import,
+    # and skipping it shaves a meaningful chunk off these heavy, duplicated-per-kernel installs.
     pip install --only-binary :all: -U pip
-    pip install --only-binary :all: \
+    pip install --only-binary :all: --no-compile \
         ipykernel \
         "dask[complete]==${dask_version}" \
         dask-gateway=="${DASK_GATEWAY_TAG}" \
@@ -68,7 +70,7 @@ for dep in $deps; do
         cpm_version=$(jq -r '."cpm_version"' <<< "${dep}")
         # asciitree (pulled in by zarr, a eopf dependency) only ships a source distribution on
         # PyPI, so it must be excluded from the --only-binary :all: constraint.
-        pip install --only-binary :all: --no-binary asciitree \
+        pip install --only-binary :all: --no-binary asciitree --no-compile \
             eopf=="${cpm_version}" \
             sentineltoolbox \
             matplotlib \


### PR DESCRIPTION
pip's --no-compile skips generating .pyc bytecode caches, which are regenerated lazily on first import anyway. They account for roughly 20-30% of installed size for packages like numpy/scipy/pandas/matplotlib (measured locally), and this install is duplicated across the 3 dpr kernels, so this trims a real chunk off the final image without changing
what's actually installed.