### PR TITLE
Fail the Jupyter image build if a dpr kernel can't import eopf/cartopy

### DIFF
--- a/.github/workflows/build-jupyter.yml
+++ b/.github/workflows/build-jupyter.yml
@@ -92,7 +92,7 @@ jobs:
     outputs:
       base: ${{ steps.filter.outputs.base }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -139,7 +139,7 @@ jobs:
       docker_images: ${{ steps.publish-docker.outputs.docker_images }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - id: publish-docker
         uses: RS-PYTHON/actions/.github/actions/publish-docker@develop
         with:
@@ -205,7 +205,7 @@ jobs:
     if: github.actor != 'dependabot[bot]' # ignore pull requests by github bot
     needs: [set-binary-env]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           repository: RS-PYTHON/rs-client-libraries
 
@@ -222,8 +222,10 @@ jobs:
     permissions:
       security-events: write # needed for github/codeql-action/upload-sarif
       packages: write # needed for 'docker push'
+    outputs:
+      docker_images: ${{ steps.publish-docker.outputs.docker_images }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Copy common requirements
         id: copy_common_req
         shell: bash
@@ -269,3 +271,34 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trivy_skip_dirs: ${{ env.TRIVY_SKIP_DIRS }}
           trivy_skip_files: ${{ env.TRIVY_SKIP_FILES }}
+
+  test-dpr-kernel-imports:
+    name: Test dpr kernel imports
+    runs-on: ubuntu-latest
+    needs: [publish-docker]
+    permissions:
+      packages: read # needed to pull the just-built image
+    steps:
+      - uses: actions/checkout@v7
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        with:
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull the built Jupyter image
+        id: image
+        env:
+          DOCKER_IMAGES: ${{ needs.publish-docker.outputs.docker_images }}
+        run: |
+          set -x
+          image="${DOCKER_IMAGES%%,*}" # first of the comma-separated list
+          docker pull "$image"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+      - name: Run the import-check notebook in every dpr kernel
+        run: |
+          ./docker/scripts/test-dpr-kernel-imports.sh \
+            "${{ steps.image.outputs.image }}" \
+            ./docker/scripts/dask-cluster-versions.yml \
+            ./docker/scripts/test-dpr-kernel-imports-cpm2.ipynb \
+            ./docker/scripts/test-dpr-kernel-imports-cpm3.ipynb

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -25,6 +25,7 @@ header:
     - '**/*.lock'
     - '**/*.md'
     - '**/*.raw'
+    - '**/*.ipynb'
     - '**/Dockerfile*'
     - '**/.gitignore'
     - '.gitmodules'

--- a/docker/scripts/create-jupyter-kernels.sh
+++ b/docker/scripts/create-jupyter-kernels.sh
@@ -38,7 +38,7 @@ cat "$deps_file"
 apt update && apt install -y jq
 
 # Install yq (https://github.com/mikefarah/yq#wget)
-wget --max-redirect=1 https://github.com/mikefarah/yq/releases/download/v4.49.2/yq_linux_amd64 -O /usr/local/bin/yq
+wget --max-redirect=1 https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64 -O /usr/local/bin/yq
 chmod +x /usr/local/bin/yq
 
 # For each set of python/dask versions

--- a/docker/scripts/test-dpr-kernel-imports-cpm2.ipynb
+++ b/docker/scripts/test-dpr-kernel-imports-cpm2.ipynb
@@ -1,0 +1,31 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from eopf.store.zarr import EOZarrStore\n",
+    "from sentineltoolbox.api import open_datatree\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import cartopy.crs as ccrs\n",
+    "import xarray as xr"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docker/scripts/test-dpr-kernel-imports-cpm3.ipynb
+++ b/docker/scripts/test-dpr-kernel-imports-cpm3.ipynb
@@ -1,0 +1,31 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from eopf.store.zarr_reader import EODataTreeZarrReader\n",
+    "from sentineltoolbox.api import open_datatree\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import cartopy.crs as ccrs\n",
+    "import xarray as xr"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docker/scripts/test-dpr-kernel-imports.sh
+++ b/docker/scripts/test-dpr-kernel-imports.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright 2023-2026 Airbus, CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verify that every Jupyter kernel used by dpr can execute a small notebook that imports eopf,
+# sentineltoolbox, matplotlib, cartopy and xarray. Exits non-zero if any kernel fails, which is
+# meant to fail the CI build.
+#
+# eopf's public API changed between its 2.x and 3.x major versions (e.g. eopf.store.zarr.EOZarrStore
+# was replaced by eopf.store.zarr_reader.EODataTreeZarrReader), so there are two notebooks: one per
+# cpm_version major version, selected per kernel from dask-cluster-versions.yml.
+
+set -euo pipefail
+set -x
+
+image=${1:-}
+deps_file=${2:-}
+notebook_cpm2=${3:-}
+notebook_cpm3=${4:-}
+if [[ (-z ${image:-}) || (-z ${deps_file:-}) || (-z ${notebook_cpm2:-}) || (-z ${notebook_cpm3:-}) ]]; then
+    echo "usage: $0 IMAGE PATH_TO_DEPS_FILE PATH_TO_CPM2_NOTEBOOK PATH_TO_CPM3_NOTEBOOK"
+    exit 2
+fi
+
+# Install yq (https://github.com/mikefarah/yq#wget)
+curl --proto '=https' --proto-redir '=https' --max-redirs 1 --fail --silent --show-error --location \
+    https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64 -o /usr/local/bin/yq
+chmod +x /usr/local/bin/yq
+
+# dpr kernels are dependency sets whose "used_by" list contains "dpr" (see dask-cluster-versions.yml)
+deps=$(yq -o json "$deps_file" | jq -c '.deps[] | select(.used_by | index("dpr") != null)')
+
+notebook_cpm2_abs=$(realpath "$notebook_cpm2")
+notebook_cpm3_abs=$(realpath "$notebook_cpm3")
+failed_kernels=()
+
+while IFS= read -r dep; do
+    python_version=$(jq -r '."python_version"' <<< "$dep")
+    dask_version=$(jq -r '."dask_version"' <<< "$dep")
+    cpm_version=$(jq -r '."cpm_version"' <<< "$dep")
+    dep_name="py${python_version}-${dask_version}"
+
+    case ${cpm_version%%.*} in
+        2) notebook_abs=$notebook_cpm2_abs ;;
+        3) notebook_abs=$notebook_cpm3_abs ;;
+        *)
+            echo "❌ Kernel '$dep_name' has an unrecognized cpm_version '$cpm_version' (expected a 2.x or 3.x major version): add a matching test notebook"
+            failed_kernels+=("$dep_name")
+            continue
+            ;;
+    esac
+
+    echo "🧪 Testing kernel: $dep_name (cpm ${cpm_version})"
+    if ! docker run --rm \
+        --entrypoint jupyter \
+        -v "${notebook_abs}:/tmp/test-dpr-kernel-imports.ipynb:ro" \
+        "$image" \
+        nbconvert --to notebook --execute \
+            --ExecutePreprocessor.kernel_name="$dep_name" \
+            --ExecutePreprocessor.timeout=300 \
+            --output /tmp/test-dpr-kernel-imports.out.ipynb \
+            /tmp/test-dpr-kernel-imports.ipynb
+    then
+        echo "❌ Kernel '$dep_name' failed to execute the test notebook"
+        failed_kernels+=("$dep_name")
+    fi
+done <<< "$deps"
+
+# Remove dependencies
+rm -f /usr/local/bin/yq
+
+if [[ ${#failed_kernels[@]} -gt 0 ]]; then
+    echo "❌ dpr kernels failing the import test: ${failed_kernels[*]}"
+    exit 1
+fi
+
+echo "✅ All dpr kernels passed the import test"


### PR DESCRIPTION
Add a CI job that runs after the Jupyter image is built and pushed: for every dependency set whose used_by list contains "dpr" in dask-cluster-versions.yml, it executes a small notebook (imports eopf, sentineltoolbox, matplotlib, cartopy, xarray) in that kernel via nbconvert, and fails the workflow if any kernel raises an import error.

This is a regression test for a runtime ModuleNotFoundError seen with botocore/aiobotocore versions resolved transitively and unpinned: nothing today would have caught a broken kernel before merge.